### PR TITLE
Add basic language switcher

### DIFF
--- a/assets/sass/components/_header.scss
+++ b/assets/sass/components/_header.scss
@@ -22,7 +22,7 @@ $header-font-color: rgba(0, 0, 0, 0.69);
   ul {
     display: flex;
     justify-content: space-between;
-    width: 430px;
+    min-width: 430px;
   }
 
   li {
@@ -30,7 +30,10 @@ $header-font-color: rgba(0, 0, 0, 0.69);
     font-size: 12.5px;
     font-weight: 700;
     line-height: 16px;
-    letter-spacing: 0.8px;
+
+    &:not(:first-child) {
+      margin-left: 1em;
+    }
 
     a {
       color: $header-font-color;

--- a/assets/sass/components/_header.scss
+++ b/assets/sass/components/_header.scss
@@ -67,6 +67,7 @@ $header-font-color: rgba(0, 0, 0, 0.69);
 
     ul {
       justify-content: flex-end;
+      min-width: unset;
     }
 
     li {

--- a/assets/sass/components/_header.scss
+++ b/assets/sass/components/_header.scss
@@ -96,7 +96,7 @@ header {
   background-color: $tangerine;
   background-size: contain;
   position: relative;
-  margin-bottom: 50px;
+  margin-bottom: 5px;
   height: 240px;
   @media screen and (min-width: $narrow) {
     height: 320px;
@@ -104,5 +104,19 @@ header {
 
   h1 {
     @extend .visually-hidden;
+  }
+}
+
+.language-switcher {
+  text-align: center;
+  margin-bottom: 1em;
+
+  li {
+    display: inline-block;
+    margin-right: 1em;
+  }
+
+  li a {
+    text-decoration: none;
   }
 }

--- a/config.toml
+++ b/config.toml
@@ -8,8 +8,8 @@ title = "Privacy Badger"
 
 [languages]
   [languages.en]
+    LanguageName = "English"
     weight = 1
-  [languages.fr]
-    weight = 2
   [languages.es]
-    weight = 3
+    LanguageName = "Español"
+    weight = 2

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,6 +5,7 @@
     <div class="content">
       {{ partial "header" . }}
       <div class="main-content home-page">
+        {{ partial "language-switcher" . }}
         <div id="badger-description">{{ i18n "privacyBadgerLearns" }}</div>
         {{ partial "download" . }}
         {{ partial "faq" . }}

--- a/layouts/partials/faq.html
+++ b/layouts/partials/faq.html
@@ -4,9 +4,11 @@
   <div class="anchors">
     <ul>
       {{ range sort .Pages ".Params.weight" (where .Pages "Section" "faqs") }}
-        <li>
-          <a href="#{{ .File.TranslationBaseName }}">{{ .Params.question }}</a>
-        </li>
+        {{ if (eq .Lang .Page.Language.Lang) }}
+          <li>
+            <a href="#{{ .File.TranslationBaseName }}">{{ .Params.question }}</a>
+          </li>
+        {{ end }}
       {{ end }}
     </ul>
   </div>

--- a/layouts/partials/language-switcher.html
+++ b/layouts/partials/language-switcher.html
@@ -1,0 +1,9 @@
+{{ if .Site.IsMultiLingual }}
+  <ul class="language-switcher">
+    {{ range .Site.Home.AllTranslations }}
+      <li>
+        <a href="{{ .Permalink }}">{{ .Language.LanguageName }}</a>
+      </li>
+    {{ end }}
+  </ul>
+{{ end }}


### PR DESCRIPTION
This adds links to the page to switch between languages. There's not a lot of room in the primary nav area for a dropdown menu, and since we only have 2 languages to switch between at the moment, I've just added them below the header for now.

![Screenshot_2019-10-18_08-38-46](https://user-images.githubusercontent.com/6469642/67109889-52e28780-f186-11e9-9513-2d5e28ac60f0.png)
