### PR TITLE
Update badger version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add --no-cache \
     findutils \
     libstdc++ \
     nodejs \
-    nodejs-npm
+    nodejs-npm \
+    curl
 
 WORKDIR /go/src/github.com/gohugoio/hugo
 RUN apk add --no-cache git build-base
@@ -19,6 +20,7 @@ COPY package.json .
 RUN npm install
 
 COPY . .
+RUN bin/update-pb-config && echo '== config.toml ==' && cat config.toml
 RUN hugo
 
 # Multi-stage build, starting new clean stage.

--- a/bin/update-pb-config
+++ b/bin/update-pb-config
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+version=$(
+    curl -f https://api.github.com/repos/EFForg/privacybadger/releases/latest \
+    | grep -Eo '"tag_name":.+' | tr -cd '0-9.'
+)
+
+if [ ! -z "$version" ]; then
+    sed -Ei "s/badgerVersion =.+/badgerVersion = \"$version\"/" config.toml
+fi

--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,7 @@ baseURL = "https://privacybadger.eff.org"
 title = "Privacy Badger"
 
 [params]
-  badgerVersion = "2019.2.19"
+  badgerVersion = "2019.11.18"
   matomoID = 36
 
 [languages]


### PR DESCRIPTION
This is to help address #37. I added a script which fetches the latest privacy badger version number and updates config.toml to reflect it, and added this as a build step for the docker image.

The image is rebuilt/deployed once a day at the moment but we could make that more frequent if needed. 