### PR TITLE
Add browser logo to main install button

### DIFF
--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -41,5 +41,5 @@ $(document).ready(function() {
   }
 
   $('#install-group img').hide()
-    .filter('[data-browser=' + browser +']').show()
+    .filter('[data-browser=' + browser + ']').show();
 });

--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -39,4 +39,7 @@ $(document).ready(function() {
       $('#android-beta-warning').show();
     }
   }
+
+  $('#install-group img').hide()
+    .filter('[data-browser=' + browser +']').show()
 });

--- a/assets/sass/components/_download.scss
+++ b/assets/sass/components/_download.scss
@@ -12,7 +12,7 @@
 #badger-download {
   margin: 20px auto 10px;
   text-align: center;
-  max-width: 400px;
+  max-width: 500px;
   border: 2px solid $orange;
   background-color: $orange;
   border-radius: 5px;
@@ -53,6 +53,26 @@
     a, span {
       color: #A5A5A5;
     }
+  }
+}
+
+#install-group {
+  display: flex;
+
+  img {
+    display: none;
+    width: 80px;
+    height: 80px;
+  }
+
+  a {
+    display: block;
+    flex: 1;
+    align-self: center;
+  }
+
+  a span {
+    display: block;
   }
 }
 

--- a/layouts/partials/download.html
+++ b/layouts/partials/download.html
@@ -2,7 +2,12 @@
   {{ range $browser, $url := $.Site.Data.browsers }}
     data-{{ $browser | urlize | safeHTMLAttr }}-url="{{ $url }}"
   {{ end }}>
-  <a>{{ i18n "installPrivacyBadger" | safeHTML }}</a>
+  <div id="install-group">
+    {{ range $browser, $url := $.Site.Data.browsers }}
+    <img src="/images/{{ urlize $browser }}.svg" data-browser="{{ urlize $browser }}" />
+    {{ end }}
+    <a>{{ i18n "installPrivacyBadger" | safeHTML }}</a>
+  </div>
 </div>
 
 <div class="version">


### PR DESCRIPTION
When a supported browser is detected, add it's logo inside the big install button. This branch fixes #19 and also incidentally fixes #40.

![Screenshot_2020-02-24_14-40-54](https://user-images.githubusercontent.com/6469642/75198734-2d5a2180-5716-11ea-8a41-9adc6f64301d.png)
