### PR TITLE
fix broken url when switching languages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 DefaultContentLanguage = "en"
-baseURL = "https://privacybadger.eff.org"
+baseURL = "https://privacybadger.org"
 title = "Privacy Badger"
 
 [params]


### PR DESCRIPTION
peculiar bug, since a dev build from hugo in the previous version would properly route everything just fine -- so I see how this slipped under our noses and into production!

this ought to fix it.