### PR TITLE
clarify dev directions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Code for <https://eff.org/privacybadger>.
 ## Development
 
 1. Install the extended version of [Hugo](https://gohugo.io/getting-started/installing/), eg `snap install hugo --channel=extended` on Linux.
-2. Install node and npm.
+2. Install node and npm. Run `npm install` to get the node dependencies.
 3. Run `hugo serve`.
 
 ## Content authoring


### PR DESCRIPTION
a nit, but worth adding as it's not immediately obvious to anyone running doing this the first time through. this just reminds the user to run `npm install` to get the js dependencies after making sure that hugo, node, and npm are installed.