### PR TITLE
Repoint Firefox installation links to AMO (addons.mozilla.org)

### DIFF
--- a/content/faqs/Can-I-download-Privacy-Badger-directly-from-eff.org.md
+++ b/content/faqs/Can-I-download-Privacy-Badger-directly-from-eff.org.md
@@ -1,0 +1,9 @@
+---
+question: Can I download Privacy Badger directly from eff.org?
+weight: 15
+---
+
+You can use the following links to get the latest version of Privacy Badger from eff.org:
+
+- Firefox: [https://www.eff.org/files/privacy-badger-latest.xpi](https://www.eff.org/files/privacy-badger-latest.xpi)
+- Chromium: [https://www.eff.org/files/privacy_badger-chrome.crx](https://www.eff.org/files/privacy_badger-chrome.crx)

--- a/content/faqs/Can-I-download-Privacy-Badger-outside-of-the-Chrome-Web-Store.md
+++ b/content/faqs/Can-I-download-Privacy-Badger-outside-of-the-Chrome-Web-Store.md
@@ -1,6 +1,0 @@
----
-question: Can I download Privacy Badger outside of the Chrome Web Store?
-weight: 15
----
-
-You can! If you are using an alternative Chromium based browser such as Chromium ports Iron, Comodo Dragon, or Maxthon you can get the latest version of the addon directly from this link: [https://www.eff.org/files/privacy_badger-chrome.crx](https://www.eff.org/files/privacy_badger-chrome.crx)

--- a/data/browsers.toml
+++ b/data/browsers.toml
@@ -1,5 +1,5 @@
 Chrome = "https://chrome.google.com/webstore/detail/privacy-badger/pkehgijcmpdhfbdbbnkijodmdjhbjlgp"
-Firefox = "https://www.eff.org/files/privacy-badger-latest.xpi"
-"Firefox on Android" = "https://www.eff.org/files/privacy-badger-latest.xpi"
+Firefox = "https://addons.mozilla.org/firefox/downloads/latest/privacy-badger17/"
+"Firefox on Android" = "https://addons.mozilla.org/firefox/downloads/latest/privacy-badger17/"
 Opera = "https://addons.opera.com/en/extensions/details/privacy-badger"
 "Microsoft Edge" = "https://microsoftedge.microsoft.com/addons/detail/mkejgcgkdlddbggjhhflekkondicpnop"


### PR DESCRIPTION
The AMO (addons.mozilla.org) version is the Recommended version, and also the only version installable in Firefox for Android.