### PR TITLE
Modify Dockerfile to copy project files earlier in build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,9 @@ RUN wget -O- https://github.com/gohugoio/hugo/archive/v$HUGO_VERSION.tar.gz|tar 
 RUN go install -v -ldflags '-s -w' -tags extended
 
 WORKDIR /build
-COPY package.json .
+COPY . .
 RUN npm install
 
-COPY . .
 RUN bin/update-pb-config && echo '== config.toml ==' && cat config.toml
 RUN hugo
 


### PR DESCRIPTION
Currently the Docker build fails due to the project files being missing during the `npm install` process. The `install` script in `package.json` is called and fails in copying over jQuery. This change copies over all the project files before running `npm install`, which was the next step in the Dockerfile.

```
> privacybadger-website@0.0.0 install
> cp node_modules/jquery/dist/jquery.min.js assets/js/vendor/
cp: can't create 'assets/js/vendor/': No such file or directory
```