### PR TITLE
Rename "install" script to "jquery" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Privacy Badger documentation site",
   "scripts": {
-    "install": "cp node_modules/jquery/dist/jquery.min.js assets/js/vendor/",
+    "jquery": "cp node_modules/jquery/dist/jquery.min.js assets/js/vendor/",
     "start": "hugo serve --renderToDisk",
     "lint": "./node_modules/.bin/sass-lint -vq && ./node_modules/.bin/eslint assets/js"
   },


### PR DESCRIPTION
Currently the Docker build fails due to the project files being missing during the `npm install` process. The `install` script in `package.json` is called and fails in copying over jQuery.

> privacybadger-website@0.0.0 install
> cp node_modules/jquery/dist/jquery.min.js assets/js/vendor/
cp: can't create 'assets/js/vendor/': No such file or directory

It appears as though prior to npm v7, the `install` script wasn't called as part of the `npm install` process but was changed:

https://docs.npmjs.com/cli/v7/using-npm/scripts/#npm-install

This PR renames the `install` script to `jquery` to preserve the old build behavior.