### PR TITLE
Install ux fixes

### DIFF
--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -30,17 +30,10 @@ $(document).ready(function() {
   }
 
   // Update DOM.
-  var $badgerDownload = $('#badger-download');
   if (browser === 'iphone' || browser === 'other') {
-    $badgerDownload.addClass('not-supported');
     $('#browser-not-supported').show();
   }
   else {
-    var url = $badgerDownload.data(browser + '-url');
-    $badgerDownload.find('a').attr('href', url);
-    $('.other-browser.' + browser).hide();
+    $('.other-browser.' + browser).addClass('active');
   }
-
-  $('#install-group img').hide()
-    .filter('[data-browser=' + browser + ']').show();
 });

--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -34,10 +34,6 @@ $(document).ready(function() {
   if (browser === 'iphone' || browser === 'other') {
     $badgerDownload.addClass('not-supported');
     $('#browser-not-supported').show();
-
-    if (browser === 'iphone') {
-      $('#browser-not-supported .iphone').show();
-    }
   }
   else {
     var url = $badgerDownload.data(browser + '-url');

--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -34,6 +34,7 @@ $(document).ready(function() {
     $('#browser-not-supported').show();
   }
   else {
-    $('.other-browser.' + browser).addClass('active');
+    $('.other-browser.' + browser).hide();
+    $('.active-browser.' + browser).show();
   }
 });

--- a/assets/js/download.js
+++ b/assets/js/download.js
@@ -30,7 +30,7 @@ $(document).ready(function() {
   }
 
   // Update DOM.
-  var $badgerDownload = $('#badger-download').show();
+  var $badgerDownload = $('#badger-download');
   if (browser === 'iphone' || browser === 'other') {
     $badgerDownload.addClass('not-supported');
     $('#browser-not-supported').show();

--- a/assets/sass/components/_download.scss
+++ b/assets/sass/components/_download.scss
@@ -9,23 +9,27 @@
   margin-right: auto;
 }
 
+#badger-download-wrapper {
+  text-align: center;
+}
+
 #badger-download {
   margin: 20px auto 10px;
   text-align: center;
-  max-width: 500px;
+  display: inline-block;
   border: 2px solid $orange;
   background-color: $orange;
   border-radius: 5px;
   font-family: 'Open Sans Condensed Bold';
   letter-spacing: 0.1em;
-  padding: 1.1em 0.8em;
+  padding: 15px 20px;
   text-transform: uppercase;
   clear: both;
   transition: background-color 0.3s ease;
 
   a {
     text-decoration: none;
-    font-size: 1.9rem;
+    font-size: 1.7rem;
     color: #FFF;
 
     span {
@@ -61,8 +65,10 @@
 
   img {
     display: none;
-    width: 80px;
-    height: 80px;
+    width: 60px;
+    height: 60px;
+    margin-inline-end: 20px;
+    align-self: center;
   }
 
   a {

--- a/assets/sass/components/_download.scss
+++ b/assets/sass/components/_download.scss
@@ -31,13 +31,28 @@
   }
 }
 
-#version {
+#other-links {
   text-align: center;
   font-size: 0.85rem;
   font-family: $sans-serif;
 
   a {
     text-decoration: none;
+  }
+
+  li {
+    display: inline;
+    margin-inline-end: 5px;
+    white-space: nowrap;
+  }
+
+  li:after {
+    margin-inline-start: 5px;
+    content: "\2022";
+  }
+
+  li:last-child:after {
+    content: none;
   }
 }
 

--- a/assets/sass/components/_download.scss
+++ b/assets/sass/components/_download.scss
@@ -55,15 +55,15 @@
   }
 }
 
-.supported-browsers {
+#supported-browsers, #active-browser {
   font-family: $sans-serif;
-  font-size: 1rem;
+  font-size: 0.85rem;
   line-height: 1.3em;
   text-align: center;
   display: flex;
   justify-content: center;
   max-width: 600px;
-  margin: 35px auto 0;
+  margin: auto;
 
   div {
     margin: 0 10px;
@@ -71,7 +71,7 @@
     width: 120px;
   }
 
-  @media screen and (max-width: 550px) {
+  @media screen and (max-width: 450px) {
     flex-wrap: wrap;
 
     div {
@@ -92,18 +92,29 @@
   }
 
   img {
-    height: 45px;
+    height: 35px;
     margin-bottom: 10px;
     opacity: 0.75;
   }
+}
 
-  div.active {
-    a, img {
-      opacity: 1;
-    }
+#active-browser {
+  font-size: 1rem;
+  margin: 25px auto 5px;
 
-    a {
-      font-weight: bold;
-    }
+  div {
+    width: auto;
+  }
+
+  a, img {
+    opacity: 1;
+  }
+
+  a {
+    font-weight: bold;
+  }
+
+  img {
+    height: 45px;
   }
 }

--- a/assets/sass/components/_download.scss
+++ b/assets/sass/components/_download.scss
@@ -1,12 +1,20 @@
-#badger-description {
+#badger-description, #dnt-gpc {
   font-size: 1.2rem;
   line-height: 1.4em;
-  max-width: 700px;
   font-family: $sans-serif;
   font-weight: 300;
   text-align: center;
-  margin-left: auto;
-  margin-right: auto;
+  margin: 0 auto;
+  max-width: 600px;
+}
+
+#dnt-gpc {
+  margin: 5px auto;
+  max-width: 500px;
+
+  a {
+    text-decoration: none;
+  }
 }
 
 #browser-not-supported {

--- a/assets/sass/components/_download.scss
+++ b/assets/sass/components/_download.scss
@@ -100,7 +100,7 @@
 
 #active-browser {
   font-size: 1rem;
-  margin: 25px auto 5px;
+  margin: 30px auto 5px;
 
   div {
     width: auto;

--- a/assets/sass/components/_download.scss
+++ b/assets/sass/components/_download.scss
@@ -1,20 +1,12 @@
-#badger-description, #dnt-gpc {
+#badger-description {
   font-size: 1.2rem;
   line-height: 1.4em;
+  max-width: 700px;
   font-family: $sans-serif;
   font-weight: 300;
   text-align: center;
-  margin: 0 auto;
-  max-width: 600px;
-}
-
-#dnt-gpc {
-  margin: 5px auto;
-  max-width: 500px;
-
-  a {
-    text-decoration: none;
-  }
+  margin-left: auto;
+  margin-right: auto;
 }
 
 #browser-not-supported {

--- a/assets/sass/components/_download.scss
+++ b/assets/sass/components/_download.scss
@@ -1,12 +1,11 @@
 #badger-description {
   font-size: 1.2rem;
   line-height: 1.4em;
-  max-width: 700px;
   font-family: $sans-serif;
   font-weight: 300;
   text-align: center;
-  margin-left: auto;
-  margin-right: auto;
+  margin: 0 auto;
+  max-width: 580px;
 }
 
 #browser-not-supported {

--- a/assets/sass/components/_download.scss
+++ b/assets/sass/components/_download.scss
@@ -9,87 +9,17 @@
   margin-right: auto;
 }
 
-#badger-download-wrapper {
-  text-align: center;
-}
-
-#badger-download {
-  margin: 20px auto 10px;
-  text-align: center;
-  display: inline-block;
-  border: 2px solid $orange;
-  background-color: $orange;
-  border-radius: 5px;
-  font-family: 'Open Sans Condensed Bold';
-  letter-spacing: 0.1em;
-  padding: 15px 20px;
-  text-transform: uppercase;
-  clear: both;
-  transition: background-color 0.3s ease;
-
-  a {
-    text-decoration: none;
-    font-size: 1.7rem;
-    color: #FFF;
-
-    span {
-      color: #000;
-      font-size: 0.75em;
-      font-family: 'Open Sans Condensed';
-    }
-  }
-
-  &:hover {
-    background-color: $tangerine;
-    cursor: pointer;
-
-    a {
-      color: $orange;
-      color: #FFF;
-      background-color: transparent;
-    }
-  }
-
-  &.not-supported {
-    border-color: #A5A5A5;
-    background-color: $light-gray;
-    cursor: default;
-    a, span {
-      color: #A5A5A5;
-    }
-  }
-}
-
-#install-group {
-  display: flex;
-
-  img {
-    display: none;
-    width: 60px;
-    height: 60px;
-    margin-inline-end: 20px;
-    align-self: center;
-  }
-
-  a {
-    display: block;
-    flex: 1;
-    align-self: center;
-  }
-
-  a span {
-    display: block;
-  }
-}
-
 #browser-not-supported {
-  margin-top: 1rem;
+  margin: 30px auto;
   text-align: center;
   max-width: 600px;
-  margin: auto;
+
+  h3 {
+    margin: 1.1rem 0;
+  }
 
   p {
-    margin-bottom: 1.6rem;
+    margin-bottom: 1.1rem;
   }
 
   .small {
@@ -97,10 +27,11 @@
     line-height: 1.6rem;
     max-width: 400px;
     margin: auto;
+    margin-bottom: 1.1rem;
   }
 }
 
-.version {
+#version {
   text-align: center;
   font-size: 0.85rem;
   font-family: $sans-serif;
@@ -110,21 +41,34 @@
   }
 }
 
-.other-browsers {
+.supported-browsers {
   font-family: $sans-serif;
-  font-size: 0.9rem;
+  font-size: 1rem;
   line-height: 1.3em;
-  padding-top: 2rem;
   text-align: center;
   display: flex;
-  justify-content: space-between;
-  max-width: 420px;
-  margin: auto;
+  justify-content: center;
+  max-width: 600px;
+  margin: 35px auto 0;
+
+  div {
+    margin: 0 10px;
+    padding: 5px 0 25px;
+    width: 120px;
+  }
+
+  @media screen and (max-width: 550px) {
+    flex-wrap: wrap;
+
+    div {
+      min-width: 120px;
+    }
+  }
 
   a {
     display: block;
     text-decoration: none;
-    opacity: 0.75;
+    opacity: 0.65;
     transition: opacity 0.3s ease;
 
     &:hover {
@@ -134,8 +78,18 @@
   }
 
   img {
-    height: 40px;
+    height: 45px;
     margin-bottom: 10px;
-    opacity: 0.85;
+    opacity: 0.75;
+  }
+
+  div.active {
+    a, img {
+      opacity: 1;
+    }
+
+    a {
+      font-weight: bold;
+    }
   }
 }

--- a/assets/sass/components/_faq.scss
+++ b/assets/sass/components/_faq.scss
@@ -1,6 +1,6 @@
 #faq {
   h3 {
-    margin-top: 45px;
+    margin-top: 50px;
 
     a {
       color: $black;
@@ -60,5 +60,19 @@
 
   a:hover {
     background-color: transparent;
+  }
+}
+
+#faq-body {
+  p {
+    margin-bottom: 1.5rem;
+  }
+
+  ul {
+    margin: 0 2rem 1.5rem;
+  }
+
+  li {
+    list-style-type: disc;
   }
 }

--- a/assets/sass/components/_header.scss
+++ b/assets/sass/components/_header.scss
@@ -101,9 +101,9 @@ header {
   background-size: contain;
   position: relative;
   margin-bottom: 5px;
-  height: 240px;
+  height: 150px;
   @media screen and (min-width: $narrow) {
-    height: 320px;
+    height: 200px;
   }
 
   h1 {
@@ -112,15 +112,25 @@ header {
 }
 
 .language-switcher {
+  font-size: 0.85rem;
   text-align: center;
   margin-bottom: 1em;
 
   li {
     display: inline-block;
-    margin-right: 1em;
+    margin-inline-end: 0.5em;
   }
 
   li a {
     text-decoration: none;
+  }
+
+  li:after {
+    margin-inline-start: 0.5em;
+    content: "\2022";
+  }
+
+  li:last-child:after {
+    content: none;
   }
 }

--- a/content/faqs/Is-Privacy-Badger-compatible-with-Firefox's-built-in-content-blocking.es.md
+++ b/content/faqs/Is-Privacy-Badger-compatible-with-Firefox's-built-in-content-blocking.es.md
@@ -10,6 +10,5 @@ Aunque existe una superposición entre las listas de rastreadores de Firefox y l
 
 Consulte también las siguientes preguntas frecuentes:
 
-[¿Es Privacy Badger compatible con otras extensiones, incluidos otros bloqueadores de anuncios?](#Is-Privacy-Badger-compatible-with-other-extensions%2c-including-other-adblockers)
-
-[¿Funciona Privacy Badger cuando se bloquean las cookies de terceros en el navegador?](#Does-Privacy-Badger-still-work-when-blocking-third-party-cookies-in-the-browser)
+- [¿Es Privacy Badger compatible con otras extensiones, incluidos otros bloqueadores de anuncios?](#Is-Privacy-Badger-compatible-with-other-extensions%2c-including-other-adblockers)
+- [¿Funciona Privacy Badger cuando se bloquean las cookies de terceros en el navegador?](#Does-Privacy-Badger-still-work-when-blocking-third-party-cookies-in-the-browser)

--- a/content/faqs/Is-Privacy-Badger-compatible-with-Firefox's-built-in-content-blocking.md
+++ b/content/faqs/Is-Privacy-Badger-compatible-with-Firefox's-built-in-content-blocking.md
@@ -9,6 +9,5 @@ While there is overlap between Firefox's tracker lists and Privacy Badger's prot
 
 See also the following FAQ entries:
 
-[Is Privacy Badger compatible with other extensions, including adblockers?](#Is-Privacy-Badger-compatible-with-other-extensions%2c-including-other-adblockers)
-
-[Does Privacy Badger still work when blocking third-party cookies in the browser?](#Does-Privacy-Badger-still-work-when-blocking-third-party-cookies-in-the-browser)
+- [Is Privacy Badger compatible with other extensions, including adblockers?](#Is-Privacy-Badger-compatible-with-other-extensions%2c-including-other-adblockers)
+- [Does Privacy Badger still work when blocking third-party cookies in the browser?](#Does-Privacy-Badger-still-work-when-blocking-third-party-cookies-in-the-browser)

--- a/content/faqs/Why-does-my-browser-connect-to-fastly.com-IP-addresses-on-startup-after-installing-Privacy-Badger.es.md
+++ b/content/faqs/Why-does-my-browser-connect-to-fastly.com-IP-addresses-on-startup-after-installing-Privacy-Badger.es.md
@@ -5,7 +5,7 @@ weight: 24
 
 EFF utiliza Fastly para alojar los recursos web de EFF: Fastly es la CDN de EFF. Privacy Badger hace ping a la CDN para los siguientes recursos a fin de garantizar que la información que contienen esté actualizada, incluso si no ha habido una nueva versión de Privacy Badger en un tiempo:
 
-https://www.eff.org/files/dnt-policies.json
-https://www.eff.org/files/cookieblocklist_new.txt
+- https://www.eff.org/files/dnt-policies.json
+- https://www.eff.org/files/cookieblocklist_new.txt
 
 EFF no instala cookies ni conserva direcciones IP para estas consultas.

--- a/content/faqs/Why-does-my-browser-connect-to-fastly.com-IP-addresses-on-startup-after-installing-Privacy-Badger.md
+++ b/content/faqs/Why-does-my-browser-connect-to-fastly.com-IP-addresses-on-startup-after-installing-Privacy-Badger.md
@@ -5,7 +5,7 @@ weight: 24
 
 EFF uses Fastly to host EFF's Web resources: Fastly is EFF's CDN. Privacy Badger pings the CDN for the following resources to ensure that the information in them is fresh even if there hasn't been a new Privacy Badger release in a while:
 
-https://www.eff.org/files/dnt-policies.json
-https://www.eff.org/files/cookieblocklist_new.txt
+- https://www.eff.org/files/dnt-policies.json
+- https://www.eff.org/files/cookieblocklist_new.txt
 
 EFF does not set cookies or retain IP addresses for these queries.

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -31,6 +31,12 @@ other = "Opera"
 [releaseNotes]
 other = "Release notes for v{{.Version}}"
 
+[otherBrowsers]
+other = "Other browsers"
+
+[altInstall]
+other = "Alternative installation options"
+
 [about]
 other = "About"
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,5 +1,5 @@
 [privacyBadgerLearns]
-other = "Privacy Badger automatically learns to block invisible trackers."
+other = "Privacy Badger is a browser extension that automatically learns to block invisible trackers."
 
 [installForBrowser]
 other = "Add to {{.Browser}}"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -2,7 +2,7 @@
 other = "Privacy Badger automatically learns to block invisible trackers."
 
 [installForBrowser]
-other = "Install for {{.Browser}}"
+other = "Add to {{.Browser}}"
 
 [browserNotSupported]
 other = "Browser Not Supported"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,9 +1,6 @@
 [privacyBadgerLearns]
 other = "Privacy Badger automatically learns to block invisible trackers."
 
-[enableDoNotTrack]
-other = "Install Privacy Badger and enable <a href='https://globalprivacycontrol.org/'>Global Privacy Control</a> and <a href='https://www.eff.org/issues/do-not-track'>Do Not Track</a>."
-
 [installForBrowser]
 other = "Add to {{.Browser}}"
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,6 +1,3 @@
-[installPrivacyBadger]
-other = "Install Privacy Badger <span>and enable Do Not Track</span>"
-
 [privacyBadgerLearns]
 other = "Privacy Badger automatically learns to block invisible trackers."
 
@@ -26,7 +23,7 @@ other = "Firefox"
 other = "Firefox on Android"
 
 [browserNameMicrosoftEdge]
-other = "Microsoft Edge"
+other = "Edge"
 
 [browserNameOpera]
 other = "Opera"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,6 +1,9 @@
 [privacyBadgerLearns]
 other = "Privacy Badger automatically learns to block invisible trackers."
 
+[enableDoNotTrack]
+other = "Install Privacy Badger and enable <a href='https://globalprivacycontrol.org/'>Global Privacy Control</a> and <a href='https://www.eff.org/issues/do-not-track'>Do Not Track</a>."
+
 [installForBrowser]
 other = "Add to {{.Browser}}"
 

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -1,5 +1,5 @@
 [privacyBadgerLearns]
-other = "Privacy Badger aprende automáticamente a bloquear los rastreadores invisibles."
+other = "Privacy Badger es una extensión de navegador que aprende automáticamente a bloquear rastreadores invisibles."
 
 [installForBrowser]
 other = "Agregar a {{.Browser}}"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -5,13 +5,13 @@ other = "Privacy Badger aprende automáticamente a bloquear los rastreadores inv
 other = "Agregar a {{.Browser}}"
 
 [browserNotSupported]
-other = "Browser no soportado"
+other = "Navegador no soportado"
 
 [notSupportedInThisBrowser]
-other = "Privacy Badger is not supported in this browser "
+other = "Privacy Badger no es compatible con este navegador"
 
 [moreInfo]
-other = "more info"
+other = "más información"
 
 [browserNameChrome]
 other = "Chrome"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -28,6 +28,12 @@ other = "Edge"
 [browserNameOpera]
 other = "Opera"
 
+[otherBrowsers]
+other = "Otros navegadores"
+
+[altInstall]
+other = "Opciones alternativas de instalación"
+
 [releaseNotes]
 other = "Notas de la versión para v{{.Version}}"
 

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -1,9 +1,6 @@
 [privacyBadgerLearns]
 other = "Privacy Badger aprende automáticamente a bloquear los rastreadores invisibles."
 
-[enableDoNotTrack]
-other = "Instale Privacy Badger y habilite <a href='https://globalprivacycontrol.org/'>Control de privacidad global</a> y <a href='https://www.eff.org/issues/do-not-track'>No rastrear</a>."
-
 [installForBrowser]
 other = "Agregar a {{.Browser}}"
 

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -2,7 +2,7 @@
 other = "Privacy Badger aprende automáticamente a bloquear los rastreadores invisibles."
 
 [installForBrowser]
-other = "Instalar para {{.Browser}}"
+other = "Agregar a {{.Browser}}"
 
 [browserNotSupported]
 other = "Browser no soportado"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -1,6 +1,3 @@
-[installPrivacyBadger]
-other = "Instale Privacy Badger <span>y habilite No rastrear</span>"
-
 [privacyBadgerLearns]
 other = "Privacy Badger aprende automáticamente a bloquear los rastreadores invisibles."
 
@@ -26,7 +23,7 @@ other = "Firefox"
 other = "Firefox para Android"
 
 [browserNameMicrosoftEdge]
-other = "Microsoft Edge"
+other = "Edge"
 
 [browserNameOpera]
 other = "Opera"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -1,6 +1,9 @@
 [privacyBadgerLearns]
 other = "Privacy Badger aprende automáticamente a bloquear los rastreadores invisibles."
 
+[enableDoNotTrack]
+other = "Instale Privacy Badger y habilite <a href='https://globalprivacycontrol.org/'>Control de privacidad global</a> y <a href='https://www.eff.org/issues/do-not-track'>No rastrear</a>."
+
 [installForBrowser]
 other = "Agregar a {{.Browser}}"
 

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -2,7 +2,7 @@
 other = "Faire Un Don"
 
 [privacyBadgerLearns]
-other = "Privacy Badger apprend automatiquement à bloquer les traqueurs invisibles."
+other = "Privacy Badger est une extension pour navigateurs qui apprend automatiquement à bloquer les traqueurs invisibles."
 
 [installForBrowser]
 other = "Installer pour {{.Browser}}"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -1,9 +1,6 @@
 [donate]
 other = "Faire Un Don"
 
-[installPrivacyBadger]
-other = "Installer Privacy Badger <span>et activer Do Not Track</span>"
-
 [privacyBadgerLearns]
 other = "Privacy Badger apprend automatiquement à bloquer les traqueurs invisibles."
 

--- a/layouts/partials/download.html
+++ b/layouts/partials/download.html
@@ -1,3 +1,7 @@
+<div id="dnt-gpc">
+  {{- i18n "enableDoNotTrack" | safeHTML -}}
+</div>
+
 <div id="browser-not-supported" class="hidden">
   <h3>{{ i18n "browserNotSupported" }}</h3>
   <p>

--- a/layouts/partials/download.html
+++ b/layouts/partials/download.html
@@ -19,15 +19,6 @@
   <p>
     {{ i18n "notSupportedInThisBrowser" }} (<a href="#Will-you-be-supporting-any-other-browsers-besides-Chrome-Firefox-Opera">{{ i18n "moreInfo" }}</a>).
   </p>
-
-  <div class="iphone hidden">
-    <p>
-      We don't yet have a version of Privacy Badger for iOS. You can <a href="https://itunes.apple.com/us/app/brave-web-browser/id1052879175">Install Brave</a>, which is a great browser with built in tracker blocking, or <a href="https://itunes.apple.com/us/app/disconnect-pro-privacy-and-performance/id1057771839">Install Disconnect Pro</a>, an app that does OS-wide tracker blocking.
-    </p>
-    <p class="small">
-      These apps are made by third parties, not EFF. You can read <a href="https://www.brave.com/ios_privacy.html" target="_blank">Brave's privacy policy</a> and <a href="https://disconnect.me/privacy" target="_blank">Disconnect's privacy policy</a>.
-    </p>
-  </div>
 </div>
 
 <div class="other-browsers">

--- a/layouts/partials/download.html
+++ b/layouts/partials/download.html
@@ -17,6 +17,14 @@
   {{ end }}
 </div>
 
-<div id="version">
+<div id="other-links">
+  <ul>
+    <li>
+      <a href="#Will-you-be-supporting-any-other-browsers-besides-Chrome-Firefox-Opera">{{ i18n "otherBrowsers" }}</a>
+    </li>
+    <li>
+      <a href="#Can-I-download-Privacy-Badger-directly-from-eff.org">{{ i18n "altInstall" }}</a>
+    </li>
+  </ul>
   <a href="https://github.com/EFForg/privacybadger/releases">{{ i18n "releaseNotes" (dict "Version" .Site.Params.badgerVersion) }}</a>
 </div>

--- a/layouts/partials/download.html
+++ b/layouts/partials/download.html
@@ -5,7 +5,19 @@
   </p>
 </div>
 
-<div class="supported-browsers">
+<div id="active-browser">
+  {{ range $browser, $url := $.Site.Data.browsers }}
+    <div class="active-browser {{ urlize $browser }}" style="display:none">
+      <a href={{$url}}>
+        <img src="/images/{{ urlize $browser }}.svg" alt="">
+        <br>
+        {{ i18n "installForBrowser" (dict "Browser" (i18n (print "browserName" (replace ($browser | title) " " "")))) }}
+      </a>
+    </div>
+  {{ end }}
+</div>
+
+<div id="supported-browsers">
   {{ range $browser, $url := $.Site.Data.browsers }}
     <div class="other-browser {{ urlize $browser }}">
       <a href={{$url}}>

--- a/layouts/partials/download.html
+++ b/layouts/partials/download.html
@@ -1,7 +1,3 @@
-<div id="dnt-gpc">
-  {{- i18n "enableDoNotTrack" | safeHTML -}}
-</div>
-
 <div id="browser-not-supported" class="hidden">
   <h3>{{ i18n "browserNotSupported" }}</h3>
   <p>

--- a/layouts/partials/download.html
+++ b/layouts/partials/download.html
@@ -1,4 +1,5 @@
-<div id="badger-download" class="hidden"
+<div id="badger-download-wrapper">
+<div id="badger-download"
   {{ range $browser, $url := $.Site.Data.browsers }}
     data-{{ $browser | urlize | safeHTMLAttr }}-url="{{ $url }}"
   {{ end }}>

--- a/layouts/partials/download.html
+++ b/layouts/partials/download.html
@@ -1,20 +1,3 @@
-<div id="badger-download-wrapper">
-<div id="badger-download"
-  {{ range $browser, $url := $.Site.Data.browsers }}
-    data-{{ $browser | urlize | safeHTMLAttr }}-url="{{ $url }}"
-  {{ end }}>
-  <div id="install-group">
-    {{ range $browser, $url := $.Site.Data.browsers }}
-    <img src="/images/{{ urlize $browser }}.svg" data-browser="{{ urlize $browser }}" />
-    {{ end }}
-    <a>{{ i18n "installPrivacyBadger" | safeHTML }}</a>
-  </div>
-</div>
-
-<div class="version">
-  <a href="https://github.com/EFForg/privacybadger/releases">{{ i18n "releaseNotes" (dict "Version" .Site.Params.badgerVersion) }}</a>
-</div>
-
 <div id="browser-not-supported" class="hidden">
   <h3>{{ i18n "browserNotSupported" }}</h3>
   <p>
@@ -22,7 +5,7 @@
   </p>
 </div>
 
-<div class="other-browsers">
+<div class="supported-browsers">
   {{ range $browser, $url := $.Site.Data.browsers }}
     <div class="other-browser {{ urlize $browser }}">
       <a href={{$url}}>
@@ -32,4 +15,8 @@
       </a>
     </div>
   {{ end }}
+</div>
+
+<div id="version">
+  <a href="https://github.com/EFForg/privacybadger/releases">{{ i18n "releaseNotes" (dict "Version" .Site.Params.badgerVersion) }}</a>
 </div>

--- a/layouts/partials/download.html
+++ b/layouts/partials/download.html
@@ -1,4 +1,4 @@
-<div id="browser-not-supported" class="hidden">
+<div id="browser-not-supported" style="display:none">
   <h3>{{ i18n "browserNotSupported" }}</h3>
   <p>
     {{ i18n "notSupportedInThisBrowser" }} (<a href="#Will-you-be-supporting-any-other-browsers-besides-Chrome-Firefox-Opera">{{ i18n "moreInfo" }}</a>).
@@ -9,7 +9,7 @@
   {{ range $browser, $url := $.Site.Data.browsers }}
     <div class="active-browser {{ urlize $browser }}" style="display:none">
       <a href={{$url}}>
-        <img src="/images/{{ urlize $browser }}.svg" alt="">
+        <img src="/images/{{ urlize $browser }}.svg" height=45 alt="">
         <br>
         {{ i18n "installForBrowser" (dict "Browser" (i18n (print "browserName" (replace ($browser | title) " " "")))) }}
       </a>
@@ -21,7 +21,7 @@
   {{ range $browser, $url := $.Site.Data.browsers }}
     <div class="other-browser {{ urlize $browser }}">
       <a href={{$url}}>
-        <img src="/images/{{ urlize $browser }}.svg" alt="">
+        <img src="/images/{{ urlize $browser }}.svg" height=35 alt="">
         <br>
         {{ i18n "installForBrowser" (dict "Browser" (i18n (print "browserName" (replace ($browser | title) " " "")))) }}
       </a>


### PR DESCRIPTION
Follows up on #19. Fixes #63.

Some users are still confused by the installation button. They look for their browser among the "other browsers" installation links and then continue to look for their browser in the FAQ. Probable underlying causes:

- Primary button too big for a button
- Primary button too close in color to the hero/header banner
- Primary button too different in style from "other browsers" installation links

This PR attempts to resolve this issue by replacing the primary button with an installation link with the same look as the "other browsers" installation links, just more prominent.

This also removes the redundant iOS-specific browser not supported text, and adds links to FAQ entries regarding unsupported browsers and alternative installation methods.

The new look:
![Screenshot from 2022-02-14 15-00-51](https://user-images.githubusercontent.com/794578/153937914-52f08295-0d44-4738-88e0-66c68b9b5d62.png)