### PR TITLE
Update Donate link in header to lead to PB-specific donate page

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -20,7 +20,7 @@
       <a href="https://www.eff.org/tools">{{ i18n "tools" }}</a>
     </li>
     <li>
-      <a href="https://supporters.eff.org/donate">{{ i18n "donate" }}</a>
+      <a href="https://supporters.eff.org/donate/support-privacy-badger">{{ i18n "donate" }}</a>
     </li>
   </ul>
 </nav>


### PR DESCRIPTION
The Dev team requested we change the Donate link on privacy badger.org to point to the PB-specific donation page. 