### PR TITLE
Update description link styling

### DIFF
--- a/assets/sass/components/_download.scss
+++ b/assets/sass/components/_download.scss
@@ -9,7 +9,10 @@
 
 #badger-description a {
   font-weight: bolder;
-  text-decoration: none;
+
+  &:visited {
+    color: $medium-blue;
+  }
 }
 
 #browser-not-supported {


### PR DESCRIPTION
- Address feedback that "EFF" in the description text was not recognizable as a link
- Add an underline (consistent with the link styling in the FAQ answers) and ensure that the text color doesn't turn gray once the link is visited (that is why the user thought the EFF link looked the same as the rest of the text)
<img width="1166" alt="Screenshot 2025-07-08 at 12 19 58 PM" src="https://github.com/user-attachments/assets/06bfde24-165f-4139-918d-4b975446a349" />
